### PR TITLE
naviflex: move hookrouter into peer dependencies

### DIFF
--- a/naviflex/package.json
+++ b/naviflex/package.json
@@ -14,15 +14,16 @@
     "prepare": "yarn build"
   },
   "peerDependencies": {
+    "hookrouter": "^1.2.3",
     "react-navigation": "^3.0.0"
   },
   "dependencies": {
-    "hookrouter": "^1.2.3",
     "react-navigation-hooks": "^1.0.2-alpha.0"
   },
   "devDependencies": {
     "@react-native-community/bob": "^0.6.1",
     "@types/hookrouter": "^2.2.1",
+    "hookrouter": "^1.2.3",
     "react-navigation": "^3.11.1",
     "tsconfig-kodefox": "^1.0.1",
     "tslint-config-kodefox": "^1.1.1",


### PR DESCRIPTION
Move hookrouter from `dependencies` into `peerDependencies` as every project that will use naviflex still has to install hookrouter to set up web router.