### PR TITLE
exoflex: change colors and roundness in default theme

### DIFF
--- a/packages/exoflex/src/constants/themes.ts
+++ b/packages/exoflex/src/constants/themes.ts
@@ -4,6 +4,48 @@ import { Theme } from '../types';
 
 export const DefaultTheme: Theme = {
   ...PaperDefaultTheme,
+  colors: {
+    /**
+     * primary color for your app, usually your brand color.
+     */
+    primary: '#0099dd',
+    /**
+     * secondary color for your app which complements the primary color.
+     */
+    accent: '#32ade3',
+    /**
+     * background color for pages, such as lists.
+     */
+    background: '#ffffff',
+    /**
+     * background color for elements containing content, such as cards.
+     */
+    surface: '#ffffff',
+    /**
+     * text color for content.
+     */
+    text: '#2d2d2d',
+    /**
+     * color for disabled elements.
+     */
+    disabled: '#e8e8e8',
+    /**
+     * color for placeholder text, such as input placeholder.
+     */
+    placeholder: '#2d2d2d',
+    /**
+     * color for backdrops of various components such as modals.
+     */
+    backdrop: 'rgba(0, 0, 0, 0.4)',
+    /**
+     * color for backdrops of various components such as modals.
+     */
+    error: '#dd0000',
+  },
+  /**
+   * roundness of common elements, such as buttons.
+   */
+  roundness: 4,
   fonts: {
     default: {
       light: {


### PR DESCRIPTION
Replace the colors and roundness from paper default theme.

The color hex came from zeplin.