### PR TITLE
exoflex: add Chip component

### DIFF
--- a/packages/exoflex/src/components/Chip.tsx
+++ b/packages/exoflex/src/components/Chip.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import {
+  TouchableOpacity,
+  StyleSheet,
+  TouchableOpacityProps,
+  StyleProp,
+  TextStyle,
+} from 'react-native';
+
+import { useTheme } from './Provider';
+import Text from './Text';
+
+type ModeProps = 'active' | 'inactive';
+
+type Props = TouchableOpacityProps & {
+  mode: ModeProps;
+  children?: string;
+  textStyle?: StyleProp<TextStyle>;
+};
+
+function Chip({
+  mode,
+  children,
+  onPress,
+  style,
+  textStyle,
+  ...otherProps
+}: Props) {
+  let { colors } = useTheme();
+
+  let isActive = mode === 'active';
+
+  return (
+    <TouchableOpacity
+      activeOpacity={0.7}
+      disabled={!onPress}
+      style={[
+        styles.root,
+        isActive
+          ? {
+              backgroundColor: colors.primary,
+            }
+          : {
+              borderColor: colors.primary,
+              borderWidth: 1,
+              backgroundColor: colors.surface,
+            },
+        style,
+      ]}
+      {...otherProps}
+    >
+      <Text
+        style={[
+          {
+            color: isActive ? colors.surface : colors.primary,
+          },
+          textStyle,
+        ]}
+      >
+        {children}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+Chip.defaultProps = {
+  mode: 'active',
+};
+
+let styles = StyleSheet.create({
+  root: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: 36,
+    paddingHorizontal: 16,
+    borderRadius: 18,
+  },
+});
+
+export default Chip;

--- a/packages/exoflex/src/components/index.ts
+++ b/packages/exoflex/src/components/index.ts
@@ -1,2 +1,3 @@
+export { default as Chip } from './Chip';
 export { default as Provider } from './Provider';
 export { default as Text } from './Text';

--- a/packages/exoflex/src/index.ts
+++ b/packages/exoflex/src/index.ts
@@ -6,4 +6,4 @@ export { BuiltInFonts } from './constants/fonts';
 export { DefaultTheme } from './constants/themes';
 
 // Components
-export { Provider, Text } from './components';
+export { Chip, Provider, Text } from './components';


### PR DESCRIPTION
Does not support icon inside the chip yet.

Didn't use Chip from react-native-paper because some of it's color cannot be customized.

Ex:
```tsx
<Chip>Active</Chip>
<Chip mode="inactive">Inactive</Chip>
```

Preview:
<img width="840" alt="image" src="https://user-images.githubusercontent.com/19742419/63830551-a01c5700-c996-11e9-930a-0e8fdd82d871.png">
