### PR TITLE
chore: use forked version of compare-url

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
             - v1-dependencies-{{ checksum "packages/naviflex/package.json" }}
             - v1-dependencies-{{ checksum "packages/exoflex/package.json" }}
             - v1-dependencies-{{ checksum "packages/miflex/package.json" }}
+            - v1-dependencies-{{ checksum "packages/flexship/package.json" }}
             # fallback to use the latest cache if no exact match is found
             - v1-dependencies-
 
@@ -56,6 +57,11 @@ jobs:
           paths:
             - packages/miflex/node_modules
           key: v1-dependencies-{{ checksum "packages/miflex/package.json" }}
+
+      - save_cache:
+          paths:
+            - packages/flexship/node_modules
+          key: v1-dependencies-{{ checksum "packages/flexship/package.json" }}
 
 workflows:
   main:


### PR DESCRIPTION
The original compare-url have issues with new branch created on the remote.

This is the issue in the original repo https://github.com/iynere/compare-url/pull/36#issuecomment-526612548