### PR TITLE
docs: add general contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,21 @@ For details, please refer to specific package contribution guidelines.
 3. If applicable, also add test to your changes.
 4. Make sure the tests are passing before creating a PR.
 5. Push and then create a PR in the repo.
+6. Wait for status checks to pass before requesting a review.
 
 ## Commit message convention
 
-Need discussion.
+This repo follows [conventional commits specification](https://www.conventionalcommits.org/en) for the commit message.
+- `build`: build related changes, e.g. change tsconfig target.
+- `chore`: non-user facing code and tooling changes, e.g. update dependencies.
+- `ci`: CI related changes, e.g. change circle CI config.
+- `docs`: changes in documentation, e.g. add Button example usage.
+- `feat`: new features, e.g. add Carousel component.
+- `fix`: bug fixes, e.g. fix missing icon in Toast.
+- `perf`: changes for improving performance, e.g. optimize Carousel render.
+- `refactor`: code refactor, e.g. refactor navigation history.
+- `revert`: revert commits, e.g. revert "use momentjs for date formatting".
+- `style`: code styling changes, e.g. run prettier on the repo.
+- `test`: add or updating tests, e.g. add test for init command.
+
+Make sure the commit message and PR title matches the commit message convention format.


### PR DESCRIPTION
TL;DR We need a commit message specification to create proper automated release notes.

---

Still not sure about the commit message.

I prefer the [conventional commit](https://www.conventionalcommits.org/en) but here in KF it's rarely used. Heck, I don't even know whether there's one in use or not, probably specific to each team?

## Commit convention choices

So here's my proposal:
1. Use the conventional commit
This will follow the conventional commit specification.
And since it's pretty common, probably there's a pre-commit lint for that specification.
No more typos and less ambiguous commit message.

We still need to discuss the allowed types and the available scopes though.

e.g. feat(exoflex): add Carousel component, chore(miflex): add release-it

2. Use our own modified conventional commit
This probably looks like what we're currently doing.

Instead of using commit type, we only use the scope.

e.g. exoflex: add Carousel component, miflex: add release-it

The cons is that we don't really know what the commit do, and it's even harder for automating the changelog.

3. (Something else, put your suggestions here 😆)


## Automated release notes

For creating automated release notes, it's better if we have a specification for the commit message.

Right now our release notes is limited at listing all the changes related to the specific packages.

For example, here's our first release from exoflex:

Exoflex 0.0.1

    exoflex: Fix RNSVG error & add alias to vector icons (#68) (8d9b98e)
    exoflex: setup release-it (#65) (41ee374)
    exoflex: add TextInput component (#54) (30595b5)
    exoflex: drawer (#64) (e03883b)
    exoflex: checkbox component (#39) (51c1b84)
    exoflex: radio button group (#59) (9c44806)
    exoflex: fix cannot resolve unimodules/core (#63) (e363d9a)

Ideally, we should be able to separate these commits into sections like bug fixes and features.
And we can hide internal changes since the target of the release note is the _user_ of the package. And the user doesn't really need to know that we fixed a typo in the codebase (unless it's a bug fix ofc).

This is where the conventional commit specification comes in.

By having the type and the scope of the commit in the message, we can select which commit will appear in the release notes and group them.


/cc @kodefox/infra 