### PR TITLE
Change compare-url to use oshimayoan/compare-url@1.2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  compare-url: oshimayoan/compare-url@1.2.3
+  compare-url: oshimayoan/compare-url@1.2.4
 
 jobs:
   testing:


### PR DESCRIPTION
This diff is consists: 
- [x] Fix for https://github.com/kodefox/infra/issues/83#issuecomment-531146773 regarding `RETURN_CODE` not changing when `git merge-base --is-ancestor` returns 0
- [x] Fix for https://github.com/kodefox/infra/issues/83#issuecomment-531195814 regarding `return code 128`
- [x] Fix for https://github.com/kodefox/infra/issues/83#issuecomment-531195814 regarding `force push`

We will use this forked orb for now until this fix coming to the original orb landed on the new version. I'm planning to open a PR there later.

This diff will close #83 