### PR TITLE
fix(exoflex): Use height instead of padding

### DIFF
--- a/packages/exoflex/src/components/Button.tsx
+++ b/packages/exoflex/src/components/Button.tsx
@@ -71,7 +71,7 @@ Button.defaultProps = {
 
 const styles = StyleSheet.create({
   contentWrapper: {
-    padding: 16,
+    height: 48,
     minWidth: 158,
   },
 });


### PR DESCRIPTION
The `padding` leads to non-visible text when the button height set to smaller than the default.

### Default
<img width="198" alt="image" src="https://user-images.githubusercontent.com/4923122/65416079-4423e180-de21-11e9-8ad4-235b264cacd9.png">

### When set to smaller height
<img width="193" alt="image" src="https://user-images.githubusercontent.com/4923122/65416117-5c93fc00-de21-11e9-98fc-90789838959c.png">

### Fix
<img width="192" alt="image" src="https://user-images.githubusercontent.com/4923122/65416167-76354380-de21-11e9-888d-eb1c845e05cf.png">
