### PR TITLE
fix(exoflex): icon styling on Collapsible component

### DIFF
--- a/packages/exoflex/example/src/App.tsx
+++ b/packages/exoflex/example/src/App.tsx
@@ -212,5 +212,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#ffffff',
     alignItems: 'center',
     justifyContent: 'center',
+    padding: 16,
   },
 });

--- a/packages/exoflex/src/components/Collapsible.tsx
+++ b/packages/exoflex/src/components/Collapsible.tsx
@@ -6,6 +6,7 @@ import {
   StyleProp,
   ViewStyle,
   TextStyle,
+  Platform,
 } from 'react-native';
 import CollapsibleBase from 'react-native-collapsible';
 import { IconButton } from 'react-native-paper';
@@ -99,19 +100,26 @@ function Collapsible({
 
 let styles = StyleSheet.create({
   root: {
+    width: '100%',
     borderWidth: 1,
   },
   titleContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-    padding: 16,
+    ...Platform.select({
+      web: { paddingHorizontal: 16 },
+      default: { padding: 16 },
+    }),
   },
   title: {
+    flex: 1,
     marginRight: 24,
   },
   icon: {
-    position: 'absolute',
-    right: 0,
+    ...Platform.select({
+      web: {},
+      default: { position: 'absolute', right: 0, alignSelf: 'center' },
+    }),
   },
   contentContainer: {
     padding: 16,


### PR DESCRIPTION
**web preview**
<img width="1280" alt="Screen Shot 2019-10-09 at 2 25 17 PM" src="https://user-images.githubusercontent.com/25707872/66460222-a545e900-eaa0-11e9-8e3c-46245080bd18.png">
**mobile preview**
![Simulator Screen Shot - iPhone 5s - 2019-10-09 at 14 21 58](https://user-images.githubusercontent.com/25707872/66460223-a545e900-eaa0-11e9-9db8-4dbd4ac709a1.png)
