### PR TITLE
build: use --frozen-lockfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
                 echo "testing ${orbname}"
                 if [ ${orbname} != "naviflex" ]; then
                   cd packages/${orbname}
-                  yarn install
+                  yarn install --frozen-lockfile
                   yarn test
                   cd ../..
                 else


### PR DESCRIPTION
Use `--frozen-lockfile` to make sure the CI will fail when `package.json` and `yarn.lock` do not sync.