### PR TITLE
feat(exoflex): add renderIconLeft and renderIconRight props to C…

### DIFF
--- a/packages/exoflex/src/components/Collapsible.tsx
+++ b/packages/exoflex/src/components/Collapsible.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ReactNode, useCallback } from 'react';
+import React, { useState, ReactNode, useCallback, useEffect } from 'react';
 import {
   Animated,
   TouchableOpacity,
@@ -18,6 +18,7 @@ import useTheme from '../helpers/useTheme';
 type Props = {
   title: string;
   children: ReactNode;
+  isCollapsed?: boolean;
   style?: StyleProp<ViewStyle>;
   titleStyle?: StyleProp<TextStyle>;
   contentContainerStyle?: StyleProp<ViewStyle>;
@@ -41,7 +42,11 @@ function Collapsible({
   ...otherProps
 }: Props) {
   let { colors } = useTheme();
-  let [isCollapsed, setCollapsed] = useState(true);
+  let [isCollapsed, setCollapsed] = useState(!!otherProps.isCollapsed);
+
+  useEffect(() => {
+    setCollapsed(!!otherProps.isCollapsed);
+  }, [otherProps.isCollapsed]);
 
   let toggleCollapsible = useCallback(() => {
     setCollapsed((c) => !c);


### PR DESCRIPTION
- add renderIconLeft & renderIconRight props
- fix default arrow. on close, should be arrow down. vice versa.

# Usage
#Usage

```
<Collapsible title="Default collapsible">
  <Text>Hello!</Text>
</Collapsible>
<Collapsible title="Default collapsible with no icon" renderIconRight={null}>
  <Text>Hello!</Text>
</Collapsible>
<Collapsible
  title="With custom right icon"
  renderIconRight={(value) => (
    <Animated.View
      style={{
        transform: [
          {
            rotate: value.interpolate({
              inputRange: [0, 1],
              outputRange: ['-45deg', '45deg'],
            }),
          },
        ],
      }}
    >
      <IconButton icon="arrow-upward" />
    </Animated.View>
  )}
>
  <Text>Hello!</Text>
</Collapsible>
<Collapsible
  title="With left icon (no animation)"
  renderIconLeft={() => <IconButton icon="arrow-downward" />}
  renderIconRight={() => null}
>
  <Text>Hello2!</Text>
</Collapsible>
<Collapsible
  title="Custom left icon and default right icon"
  renderIconLeft={() => <IconButton icon="camera" style={{ margin: 0 }} />}
>
  <Text>Hello!</Text>
</Collapsible>
```
**web preview**
![Kapture 2019-10-10 at 18 05 21](https://user-images.githubusercontent.com/25707872/66564424-288f3980-eb8a-11e9-8dff-76568fef9f78.gif)
**mobile preview**
![Kapture 2019-10-10 at 18 06 44](https://user-images.githubusercontent.com/25707872/66564425-2927d000-eb8a-11e9-9e28-1f01d2c0a5be.gif)
