### PR TITLE
fix(exoflex): remove absolute positioning from switch's thumb

### DIFF
--- a/packages/exoflex/src/components/Switch.tsx
+++ b/packages/exoflex/src/components/Switch.tsx
@@ -37,7 +37,6 @@ export default function Switch(props: Props) {
       margin: MARGIN,
       alignItems: 'center',
       justifyContent: 'center',
-      position: 'absolute',
       backgroundColor: colors.background,
       width: thumbSize,
       height: thumbSize,


### PR DESCRIPTION
IDK when, but seems like our switch broke on the web because of the absolute positioning.

Before:
<img width="81" alt="image" src="https://user-images.githubusercontent.com/19742419/66731698-dc424300-ee82-11e9-812c-7075b1f40cd1.png">

After:
<img width="80" alt="image" src="https://user-images.githubusercontent.com/19742419/66731716-f2e89a00-ee82-11e9-89ec-76b4a761c22c.png">
