### PR TITLE
build(exoflex): run build script on prepare

### DIFF
--- a/packages/exoflex/package.json
+++ b/packages/exoflex/package.json
@@ -11,6 +11,7 @@
   "author": "KodeFox",
   "license": "MIT",
   "scripts": {
+    "prepare": "yarn build",
     "build": "yarn bob build",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx}\"",


### PR DESCRIPTION
Make sure the library will be built when *prepare* script is running. So there won't be any chance that we will forget to build the library before releasing it.

> prepare: Run both BEFORE the package is packed and published, on local npm install without any arguments, and when installing git dependencies (See below). This is run AFTER prepublish, but BEFORE prepublishOnly.

Ref: https://docs.npmjs.com/misc/scripts