### PR TITLE
fix(exoflex): fix invalid property passed to DOM

### DIFF
--- a/packages/exoflex/src/components/svg/Check.tsx
+++ b/packages/exoflex/src/components/svg/Check.tsx
@@ -13,7 +13,7 @@ let Check = (props: IconProps) => {
       <Path
         d="M13.28 20.72a1.328 1.328 0 0 1-1.88 0l-4.787-4.787a1.329 1.329 0 0 1 1.88-1.88l3.84 3.84 9.174-9.173a1.329 1.329 0 1 1 1.88 1.88L13.28 20.72z"
         fill={props.fill || DefaultTheme.colors.placeholder}
-        fill-rule="nonzero"
+        fillRule="nonzero"
       />
       <Path d="M0 0h17.55v17.55H0z" fill="transparent" />
     </Svg>


### PR DESCRIPTION
<img width="446" alt="image" src="https://user-images.githubusercontent.com/19742419/66893685-d41c0c00-f018-11e9-997a-4438fdbe94cf.png">
