### PR TITLE
fix(exoflex): use ReactNode for Text.children

### DIFF
--- a/packages/exoflex/src/components/Text.tsx
+++ b/packages/exoflex/src/components/Text.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, ReactNode } from 'react';
 import { Text as TextNative, TextProps } from 'react-native';
 
 import resolveTextStyle from '../helpers/resolveTextStyle';
@@ -6,7 +6,7 @@ import useTheme from '../helpers/useTheme';
 import { FontWeight, FontStyle } from '../types';
 
 export type Props = TextProps & {
-  children?: string;
+  children?: ReactNode;
   preset: string;
   weight: FontWeight;
   fontStyle: FontStyle;


### PR DESCRIPTION
This should fix various type errors like unable to use nested Text.