### PR TITLE
test(exoflex): fix DateTimePicker tests

### DIFF
--- a/packages/exoflex/src/components/DateTimePicker/DateTimePicker.web.tsx
+++ b/packages/exoflex/src/components/DateTimePicker/DateTimePicker.web.tsx
@@ -84,6 +84,7 @@ export function DatePicker(props: PickerProps) {
   return (
     <>
       <Calendar
+        current={selectedDate}
         markedDates={{ [selectedDate.split('T')[0]]: { selected: true } }}
         onDayPress={changeDate}
       />

--- a/packages/exoflex/src/components/__tests__/DateTimePicker.test.web.tsx
+++ b/packages/exoflex/src/components/__tests__/DateTimePicker.test.web.tsx
@@ -21,7 +21,7 @@ describe('DateTimePicker', () => {
       date = newDate;
     });
     let onCancel = jest.fn();
-    let selectedDate = new Date(new Date(date).setDate(27));
+    let selectedDate = new Date(new Date(date).setDate(9));
 
     const App = () => {
       let [isVisible, setVisible] = useState(false);
@@ -43,9 +43,9 @@ describe('DateTimePicker', () => {
     act(() => {
       fireEvent.click(getByText('OPEN'));
     });
-    await wait(() => getByText('27'));
+    await wait(() => getByText('CONFIRM'));
 
-    fireEvent.click(getByText('27'));
+    fireEvent.click(getByText('9'));
     fireEvent.click(getByText('CONFIRM'));
     expect(onConfirm).toHaveBeenCalled();
     expect(date).toBe(new Date(selectedDate).toISOString());
@@ -97,7 +97,7 @@ describe('DateTimePicker', () => {
     });
     let onCancel = jest.fn();
     let selectedDate = new Date(
-      new Date(new Date(date).setMinutes(27)).setDate(27),
+      new Date(new Date(date).setMinutes(27)).setDate(9),
     );
 
     const App = () => {
@@ -121,7 +121,7 @@ describe('DateTimePicker', () => {
     });
     await wait(() => getByText('CONFIRM'));
 
-    fireEvent.click(getByText('27'));
+    fireEvent.click(getByText('9'));
     fireEvent.click(getByText('CONFIRM'));
     await wait(() => getByText('Hrs'));
 


### PR DESCRIPTION
In this month, November 2019, the date of 27th is rendered twice and causing `getByText('27')` to found more than one element.