### PR TITLE
fix(exoflex): resize icon on TimePicker web

### DIFF
--- a/packages/exoflex/src/components/TimePicker/TimePickerInput.tsx
+++ b/packages/exoflex/src/components/TimePicker/TimePickerInput.tsx
@@ -152,10 +152,10 @@ function TimePickerArrow(props: TimePickerArrowProps) {
 }
 
 function ArrowUp() {
-  return <IconButton icon="chevron-up" style={styles.arrow} />;
+  return <IconButton icon="chevron-up" size={20} style={styles.arrow} />;
 }
 function ArrowDown() {
-  return <IconButton icon="chevron-down" style={styles.arrow} />;
+  return <IconButton icon="chevron-down" size={20} style={styles.arrow} />;
 }
 
 // NOTE: React.memo needed to boost performance on mobile web


### PR DESCRIPTION
### Before
<img width="426" alt="image" src="https://user-images.githubusercontent.com/4923122/69325674-14f0eb80-0c7d-11ea-8077-f4608a5c98d6.png">

### After
<img width="411" alt="image" src="https://user-images.githubusercontent.com/4923122/69325687-1a4e3600-0c7d-11ea-846e-64c0c2d8563e.png">
