### PR TITLE
fix(exoflex): handle locale on native TimePicker

### DIFF
--- a/packages/exoflex/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/packages/exoflex/src/components/DateTimePicker/DateTimePicker.tsx
@@ -9,6 +9,8 @@ export default function DateTimePicker(props: DateTimePickerProps) {
     onConfirm,
     date = new Date().toISOString(),
     mode = 'datetime' as DateTimePickerMode,
+    is24Hour = false,
+    locale,
     ...otherProps
   } = props;
 
@@ -16,6 +18,9 @@ export default function DateTimePicker(props: DateTimePickerProps) {
     <RNDateTimePicker
       mode={mode}
       date={date.trim() === '' ? new Date() : new Date(date)}
+      is24Hour={is24Hour}
+      // NOTE: If locale is not provided, use `en-GB` for 12h format
+      locale={locale || is24Hour ? 'en-GB' : 'en-US'}
       onCancel={() => onCancel()}
       onConfirm={(newDate) => onConfirm(newDate.toISOString())}
       {...otherProps}

--- a/packages/exoflex/src/components/DateTimePicker/DateTimePicker.web.tsx
+++ b/packages/exoflex/src/components/DateTimePicker/DateTimePicker.web.tsx
@@ -15,6 +15,7 @@ export default function DateTimePicker(props: DateTimePickerProps) {
     mode = 'datetime' as DateTimePickerMode,
     date = new Date().toISOString(),
     isVisible,
+    is24Hour,
     onCancel,
     onConfirm,
     minimumDate,
@@ -48,6 +49,7 @@ export default function DateTimePicker(props: DateTimePickerProps) {
     ) : (
       <TimePickerContainer
         date={dateTime}
+        is24Hour={is24Hour}
         onCancel={cancel}
         onConfirm={confirmTime}
       />
@@ -76,6 +78,7 @@ export type PickerProps = Readonly<{
   date: string;
   minDate?: Date;
   maxDate?: Date;
+  is24Hour?: boolean;
   onCancel: () => void;
   onConfirm: (date: string) => void;
 }>;
@@ -113,7 +116,7 @@ export function DatePicker(props: PickerProps) {
 }
 
 export function TimePickerContainer(props: PickerProps) {
-  let { date, onCancel, onConfirm } = props;
+  let { date, is24Hour, onCancel, onConfirm } = props;
   let { colors } = useTheme();
 
   let [selectedDateTime, setSelectedDateTime] = useState(date);
@@ -124,7 +127,12 @@ export function TimePickerContainer(props: PickerProps) {
   return (
     <>
       <View style={{ alignItems: 'center', marginTop: 12 }}>
-        <TimePicker date={selectedDateTime} onChangeTime={changeTime} />
+        {/* TODO: Handle format based on locale too */}
+        <TimePicker
+          date={selectedDateTime}
+          format={is24Hour ? '24' : '12'}
+          onChangeTime={changeTime}
+        />
       </View>
       <View style={styles.touchableActionWrapper}>
         <TouchableRipple onPress={onCancel} style={styles.touchableAction}>

--- a/packages/exoflex/src/components/TimePicker/TimePicker.tsx
+++ b/packages/exoflex/src/components/TimePicker/TimePicker.tsx
@@ -14,6 +14,7 @@ export default function TimePicker(props: TimePickerProps) {
     date,
     placeholder = '',
     title = '',
+    locale,
     onChangeTime,
     style,
   } = props;
@@ -56,8 +57,8 @@ export default function TimePicker(props: TimePickerProps) {
         titleIOS={title}
         // NOTE: Android only
         is24Hour={is24Hour}
-        // NOTE: For determining 12h or 24h in iOS
-        locale={is24Hour ? 'id-ID' : 'en-US'}
+        // NOTE: If locale is not provided, use `en-GB` for 12h format
+        locale={locale || is24Hour ? 'en-GB' : 'en-US'}
         isVisible={visible}
         mode="time"
         onConfirm={changeDate}

--- a/packages/exoflex/src/components/TimePicker/types.ts
+++ b/packages/exoflex/src/components/TimePicker/types.ts
@@ -6,6 +6,7 @@ export type TimePickerProps = Readonly<{
   format?: HourFormat;
   placeholder?: string;
   title?: string;
+  locale?: string;
   onChangeTime?: (utcString: string) => void;
   style?: StyleProp<TextStyle>;
 }>;


### PR DESCRIPTION
Makes native TimePicker be able to handle the format based on locale too. Not just from `is24Hour` prop.

This is based on https://github.com/kodefox/oasis/pull/74#discussion_r351991059

