### PR TITLE
fix(exoflex): change error icon

### DIFF
--- a/packages/exoflex/src/components/TextInput/ErrorIcon.tsx
+++ b/packages/exoflex/src/components/TextInput/ErrorIcon.tsx
@@ -12,7 +12,7 @@ type Props = {
 export default function ErrorIcon(props: Props) {
   return (
     <View style={styles.errorIconContainer}>
-      <IconButton icon="error-outline" {...props} />
+      <IconButton icon="alert-circle-outline" {...props} />
     </View>
   );
 }


### PR DESCRIPTION
Use `alert-circle-outline` instead of `error-outline` because MaterialCommunityIcon does not have it.

<img width="355" alt="image" src="https://user-images.githubusercontent.com/4923122/70694003-3465bc00-1cf1-11ea-8bc0-2a52fae1327a.png">
