### PR TITLE
chore: ignore deps for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,17 @@
 {
-  "extends": ["config:base"],
-  "labels": ["dependencies", "ready for review"],
+  "extends": [
+    "config:base"
+  ],
+  "labels": [
+    "dependencies",
+    "ready for review"
+  ],
   "prHourlyLimit": 2,
-  "semanticCommitScope": null
+  "semanticCommitScope": null,
+  "ignoreDeps": [
+    "react-native-svg",
+    "react-native-gesture-handler",
+    "react-native-reanimated",
+    "react-native-screens"
+  ]
 }


### PR DESCRIPTION
Tell renovate to ignore packages from `expo install`.