### PR TITLE
feat(exoflex): change button uppercase through theme

### DIFF
--- a/packages/exoflex/src/components/Button/Button.tsx
+++ b/packages/exoflex/src/components/Button/Button.tsx
@@ -2,19 +2,25 @@ import React from 'react';
 import ButtonRipple from './ButtonRipple';
 import ButtonOpacity from './ButtonOpacity';
 
+import useTheme from '../../helpers/useTheme';
+
 import { ButtonProps } from './types';
 
 export default function Button(props: ButtonProps) {
-  let { useRipple = false, ...otherProps } = props;
+  let { uppercase: uppercaseTheme } = useTheme();
+  let {
+    useRipple = false,
+    uppercase = uppercaseTheme.button,
+    ...otherProps
+  } = props;
 
   if (useRipple) {
-    return <ButtonRipple {...otherProps} />;
+    return <ButtonRipple uppercase={uppercase} {...otherProps} />;
   }
 
-  return <ButtonOpacity {...otherProps} />;
+  return <ButtonOpacity uppercase={uppercase} {...otherProps} />;
 }
 
 Button.defaultProps = {
   preset: 'primary',
-  uppercase: true,
 };

--- a/packages/exoflex/src/constants/themes.ts
+++ b/packages/exoflex/src/constants/themes.ts
@@ -184,6 +184,7 @@ export const DefaultTheme: Theme = {
   roundness: 4,
   fonts: SystemFonts,
   uppercase: {
+    button: true,
     textinput: false,
   },
 };

--- a/packages/exoflex/src/types.ts
+++ b/packages/exoflex/src/types.ts
@@ -14,6 +14,7 @@ export type Theme = {
     scale: number;
   };
   uppercase: {
+    button: boolean;
     textinput: boolean;
   };
 };


### PR DESCRIPTION
Followup diff from #269. 

Add the capability to change the button's text whether to use uppercase or not through the theme. So the engineers could change it across the app easily.