### PR TITLE
fix(eslint-config-kodefox): fix import rule definition not found

### DIFF
--- a/packages/eslint-config-kodefox/index.js
+++ b/packages/eslint-config-kodefox/index.js
@@ -7,7 +7,7 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
-  plugins: ['eslint-comments', 'prettier'],
+  plugins: ['eslint-comments', 'import', 'prettier'],
   extends: [
     'plugin:@typescript-eslint/recommended',
     'prettier',


### PR DESCRIPTION
PR #349 is missing the plugins part, causing the rule definition to be not found.

Probably we need a way to test our eslint config.