### PR TITLE
fix(exoflex): useErrorIcon to showErrorIcon

### DIFF
--- a/packages/exoflex/src/components/TextInput/TextInput.tsx
+++ b/packages/exoflex/src/components/TextInput/TextInput.tsx
@@ -18,7 +18,7 @@ function TextInput(props: TextInputProps, ref: Ref<NativeTextInput>) {
     editable = true,
     mode = 'outlined',
     uppercase = uppercaseTheme.textinput,
-    useErrorIcon = true,
+    showErrorIcon = true,
     onFocus,
     onBlur,
     onChangeText,
@@ -65,7 +65,7 @@ function TextInput(props: TextInputProps, ref: Ref<NativeTextInput>) {
     <TextInputOutlined
       {...otherProps}
       ref={ref}
-      useErrorIcon={useErrorIcon}
+      showErrorIcon={showErrorIcon}
       uppercase={uppercase}
       autoCorrect={autoCorrect}
       disabled={disabled}
@@ -79,7 +79,7 @@ function TextInput(props: TextInputProps, ref: Ref<NativeTextInput>) {
     <TextInputFlat
       {...otherProps}
       ref={ref}
-      useErrorIcon={useErrorIcon}
+      showErrorIcon={showErrorIcon}
       uppercase={uppercase}
       autoCorrect={autoCorrect}
       disabled={disabled}

--- a/packages/exoflex/src/components/TextInput/TextInputFlat.tsx
+++ b/packages/exoflex/src/components/TextInput/TextInputFlat.tsx
@@ -34,7 +34,7 @@ export function TextInputFlat(props: Props, ref: Ref<TextInput>) {
     uppercase,
     value,
     numberOfLines,
-    useErrorIcon,
+    showErrorIcon,
     style,
     containerStyle,
     labelStyle,
@@ -100,7 +100,7 @@ export function TextInputFlat(props: Props, ref: Ref<TextInput>) {
           ]}
           {...otherProps}
         />
-        {isError && useErrorIcon && <ErrorIcon color={colors.error} />}
+        {isError && showErrorIcon && <ErrorIcon color={colors.error} />}
       </View>
       {isError && (
         <ErrorMessage

--- a/packages/exoflex/src/components/TextInput/TextInputOutlined.tsx
+++ b/packages/exoflex/src/components/TextInput/TextInputOutlined.tsx
@@ -28,7 +28,7 @@ function TextInputOutlined(
     uppercase,
     value,
     numberOfLines,
-    useErrorIcon,
+    showErrorIcon,
     style,
     containerStyle,
     labelStyle,
@@ -87,7 +87,7 @@ function TextInputOutlined(
           ]}
           {...otherProps}
         />
-        {isError && useErrorIcon && <ErrorIcon color={colors.error} />}
+        {isError && showErrorIcon && <ErrorIcon color={colors.error} />}
       </View>
       {isError && (
         <ErrorMessage style={[styles.errorMessage, errorMessageStyle]}>

--- a/packages/exoflex/src/components/TextInput/types.ts
+++ b/packages/exoflex/src/components/TextInput/types.ts
@@ -38,7 +38,7 @@ export type TextInputProps = BaseTextInputProps & {
    * Determine to use error icon or not.
    * Defaults to 'true'.
    */
-  useErrorIcon?: boolean;
+  showErrorIcon?: boolean;
   /**
    * Additional style passed to the container of the TextInput
    */


### PR DESCRIPTION
Rename TextInput prop `useErrorIcon` into `showErrorIcon`.