### PR TITLE
fix(eslint-config-kodefox): Use warn instead of error for import statement order

### DIFF
--- a/packages/eslint-config-kodefox/index.js
+++ b/packages/eslint-config-kodefox/index.js
@@ -49,12 +49,12 @@ module.exports = {
 
     // Import/export syntax (eslint-plugin-import)
     'import/no-useless-path-segments': [
-      'error',
+      'warn',
       {
         noUselessIndex: true,
       },
     ],
-    'import/order': ['error', { 'newlines-between': 'always' }],
+    'import/order': ['warn', { 'newlines-between': 'always' }],
 
     // Custom
     'array-callback-return': 'warn',


### PR DESCRIPTION
The reason for this update is that the red underline on imports usually means there's no module found, so having this use the same level of error is a bit confusing.