### PR TITLE
ci: upgrade node version to 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   testing:
     docker:
-      - image: circleci/node:8.17.0
+      - image: circleci/node:10.18.1
 
     working_directory: ~/repo
 


### PR DESCRIPTION
The reason I upgrade our node version is that Jest 25 need node >= 10 to be installed.

Honestly, I'd like to wait until this [issue](https://github.com/facebook/jest/issues/9457) is solved before we upgrade our Jest to version 25. But recently we got a potential security vulnerability from one of our dependencies, which is `handlebars`. That dependency is actually a dependency from Jest, so that's why we need to upgrade Jest to version 25.