### PR TITLE
feat(eslint-config-kodefox): module based import order

### DIFF
--- a/packages/eslint-config-kodefox/index.js
+++ b/packages/eslint-config-kodefox/index.js
@@ -7,7 +7,7 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
-  plugins: ['eslint-comments', 'import', 'prettier'],
+  plugins: ['eslint-comments', 'import', 'import-helpers', 'prettier'],
   extends: [
     'plugin:@typescript-eslint/recommended',
     'prettier',
@@ -54,7 +54,18 @@ module.exports = {
         noUselessIndex: true,
       },
     ],
-    'import/order': ['warn', { 'newlines-between': 'always' }],
+    'import-helpers/order-imports': [
+      'warn',
+      {
+        newlinesBetween: 'always',
+        groups: [
+          'module',
+          ['parent', 'sibling', 'index'],
+          ['//use[A-Z].*/', '//helper(s?)/'],
+          ['//constant(s?)/', '/type(s?)/'],
+        ],
+      },
+    ],
 
     // Custom
     'array-callback-return': 'warn',

--- a/packages/eslint-config-kodefox/package.json
+++ b/packages/eslint-config-kodefox/package.json
@@ -25,6 +25,7 @@
     "eslint-config-prettier": "^6.5.0",
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.20.1",
+    "eslint-plugin-import-helpers": "^1.0.2",
     "eslint-plugin-prettier": "^3.1.1"
   },
   "devDependencies": {

--- a/packages/eslint-config-kodefox/yarn.lock
+++ b/packages/eslint-config-kodefox/yarn.lock
@@ -352,6 +352,11 @@ eslint-plugin-eslint-plugin@^2.1.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-2.1.0.tgz#a7a00f15a886957d855feacaafee264f039e62d5"
   integrity sha512-kT3A/ZJftt28gbl/Cv04qezb/NQ1dwYIbi8lyf806XMxkus7DvOVCLIfTXMrorp322Pnoez7+zabXH29tADIDg==
 
+eslint-plugin-import-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import-helpers/-/eslint-plugin-import-helpers-1.0.2.tgz#ae0ab47c991c65e1b25b6370f49afa2cab4cbd9c"
+  integrity sha512-aSoqeEEkJou/1NhbSO7Xr2SKSs8mI53qe8uFh9tMl4WCbrOwoel0eA3hRajlJ7MLCG44umf+mY3/dWuufneFzw==
+
 eslint-plugin-import@^2.20.1:
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz#802423196dcb11d9ce8435a5fc02a6d3b46939b3"
@@ -644,9 +649,9 @@ has@^1.0.3:
     function-bind "^1.1.1"
 
 hosted-git-info@^2.1.4:
-  version "2.8.5"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
-  integrity sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
+  integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
 
 iconv-lite@^0.4.24:
   version "0.4.24"


### PR DESCRIPTION
This is kinda my proposal for `import order`.

Currently, our `import order` is based on the *path parenthesis*. So the default order is from `builtin` then `external` then `internal` then `parent path` then `sibling path` then `index`.

I don't think such order is our usual approach as the we did in the past. Thus, I make this proposal to make the `import order` based on the module type.

So first goes the `module` then `parent/sibling/index` as the same level, then `custom hooks/helpers` as the same level, then `type/constant` as the same level. In my opinion, that is the most similar approach that we used in the past. Of course, we can tweak the order if there is any suggestion.

Here is what happens when we put a `constant` file on top of a component file:

![image](https://user-images.githubusercontent.com/4923122/76755303-3474cc80-67b6-11ea-85e8-e2a67ec3e297.png)

And here is the error message:

![image](https://user-images.githubusercontent.com/4923122/76755423-6a19b580-67b6-11ea-8dc9-741ddcd4b0a2.png)

Lastly, here is the example repo if you want to try it yourself.
https://github.com/oshimayoan/import-order-example