### PR TITLE
fix(exoflex): export useTheme

### DIFF
--- a/packages/exoflex/src/index.ts
+++ b/packages/exoflex/src/index.ts
@@ -49,3 +49,6 @@ export {
   Label,
   Caption,
 } from './components/Typography';
+
+// Hooks
+export { default as useTheme } from './helpers/useTheme';


### PR DESCRIPTION
Export `useTheme` so the user could also use it from their own component.