### PR TITLE
chore: ignore few deps from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
     "@react-native-community/bob",
     "@react-native-community/datetimepicker",
     "babel-preset-expo",
+    "chalk",
     "expo",
     "expo-font",
     "react",

--- a/renovate.json
+++ b/renovate.json
@@ -4,12 +4,22 @@
   "prHourlyLimit": 2,
   "semanticCommitScope": null,
   "ignoreDeps": [
-    "react-native-svg",
+    "@expo/webpack-config",
+    "@react-native-community/bob",
+    "@react-native-community/datetimepicker",
+    "babel-preset-expo",
+    "expo",
+    "expo-font",
+    "react",
+    "react-dom",
+    "react-native",
     "react-native-gesture-handler",
+    "react-native-modal-datetime-picker",
     "react-native-reanimated",
     "react-native-screens",
-    "expo-font",
-    "react-native-modal-datetime-picker",
-    "@react-native-community/datetimepicker"
+    "react-native-svg",
+    "react-native-web",
+    "react-test-renderer",
+    "release-it"
   ]
 }


### PR DESCRIPTION
The reason why I chose to ignore these deps is that it will be way better to maintain if we manually update them. Because a few of them are somewhat depends on Expo version or each other.