### PR TITLE
feat(exoflex): new feature for calendar

### DIFF
--- a/packages/exoflex/example/package.json
+++ b/packages/exoflex/example/package.json
@@ -36,7 +36,7 @@
     "babel-preset-expo": "8.0.0",
     "lodash.mergewith": "4.6.2",
     "react-native-animation-hooks": "1.0.1",
-    "react-native-calendars": "1.265.0",
+    "react-native-calendars": "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.1.tar.gz",
     "react-native-collapsible": "1.5.2",
     "react-native-modal-datetime-picker": "8.1.1",
     "react-native-paper": "3.8.0",

--- a/packages/exoflex/example/package.json
+++ b/packages/exoflex/example/package.json
@@ -36,7 +36,7 @@
     "babel-preset-expo": "8.0.0",
     "lodash.mergewith": "4.6.2",
     "react-native-animation-hooks": "1.0.1",
-    "react-native-calendars": "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.1.tar.gz",
+    "react-native-calendars": "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.2.tar.gz",
     "react-native-collapsible": "1.5.2",
     "react-native-modal-datetime-picker": "8.1.1",
     "react-native-paper": "3.8.0",

--- a/packages/exoflex/example/package.json
+++ b/packages/exoflex/example/package.json
@@ -36,7 +36,7 @@
     "babel-preset-expo": "8.0.0",
     "lodash.mergewith": "4.6.2",
     "react-native-animation-hooks": "1.0.1",
-    "react-native-calendars": "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.2.tar.gz",
+    "react-native-calendars": "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.3.tar.gz",
     "react-native-collapsible": "1.5.2",
     "react-native-modal-datetime-picker": "8.1.1",
     "react-native-paper": "3.8.0",

--- a/packages/exoflex/example/yarn.lock
+++ b/packages/exoflex/example/yarn.lock
@@ -9059,9 +9059,9 @@ react-native-animation-hooks@1.0.1:
   resolved "https://registry.yarnpkg.com/react-native-animation-hooks/-/react-native-animation-hooks-1.0.1.tgz#fcda58867d708084cc63c6fcd001f5375a40f45b"
   integrity sha512-s1o71m9sPpEYwFpHTdBouO50jzvyxIVB4MmNwfVGgPWkdL02zKOzyXcNuPJmoCuLIstUj5TBEwtnGk1WMFJx5A==
 
-"react-native-calendars@https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.2.tar.gz":
-  version "0.0.2"
-  resolved "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.2.tar.gz#1eb8276a06844c2fc66ade9ad94c74b081ab5816"
+"react-native-calendars@https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.3.tar.gz":
+  version "0.0.3"
+  resolved "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.3.tar.gz#60bd33bbd3cefa3ff0031e979b98ba766a3ab695"
   dependencies:
     hoist-non-react-statics "^3.3.1"
     lodash "^4.0.0"

--- a/packages/exoflex/example/yarn.lock
+++ b/packages/exoflex/example/yarn.lock
@@ -9059,9 +9059,9 @@ react-native-animation-hooks@1.0.1:
   resolved "https://registry.yarnpkg.com/react-native-animation-hooks/-/react-native-animation-hooks-1.0.1.tgz#fcda58867d708084cc63c6fcd001f5375a40f45b"
   integrity sha512-s1o71m9sPpEYwFpHTdBouO50jzvyxIVB4MmNwfVGgPWkdL02zKOzyXcNuPJmoCuLIstUj5TBEwtnGk1WMFJx5A==
 
-"react-native-calendars@https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.1.tar.gz":
-  version "1.22.0"
-  resolved "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.1.tar.gz#3750211597de33b4980d837724751f8aa56209ad"
+"react-native-calendars@https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.2.tar.gz":
+  version "0.0.2"
+  resolved "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.2.tar.gz#1eb8276a06844c2fc66ade9ad94c74b081ab5816"
   dependencies:
     hoist-non-react-statics "^3.3.1"
     lodash "^4.0.0"

--- a/packages/exoflex/example/yarn.lock
+++ b/packages/exoflex/example/yarn.lock
@@ -7570,6 +7570,11 @@ mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
+months@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/months/-/months-2.1.0.tgz#9385ae1968b84313dff223b11080058d1ec326fd"
+  integrity sha512-2M9gdDB/uVt304/hJ3k2UIquJhOV5dRjp9BovHmZSINaRp7pdJuHXxOcuSjmJaKNomFyYyu0y3LBigdWiAUEmQ==
+
 morgan@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
@@ -9054,13 +9059,13 @@ react-native-animation-hooks@1.0.1:
   resolved "https://registry.yarnpkg.com/react-native-animation-hooks/-/react-native-animation-hooks-1.0.1.tgz#fcda58867d708084cc63c6fcd001f5375a40f45b"
   integrity sha512-s1o71m9sPpEYwFpHTdBouO50jzvyxIVB4MmNwfVGgPWkdL02zKOzyXcNuPJmoCuLIstUj5TBEwtnGk1WMFJx5A==
 
-react-native-calendars@1.265.0:
-  version "1.265.0"
-  resolved "https://registry.yarnpkg.com/react-native-calendars/-/react-native-calendars-1.265.0.tgz#4144408254afaebc97213708e3c7d911dc73a335"
-  integrity sha512-iOv5JXgo7Dm9yQ+P0PE5a8tmxGUHwGQOk1AddD8cmNZiuCIAv5G3f5fuBRJ8+sLcNdic1tamrh+e8A4UNMZsHA==
+"react-native-calendars@https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.1.tar.gz":
+  version "1.22.0"
+  resolved "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.1.tar.gz#3750211597de33b4980d837724751f8aa56209ad"
   dependencies:
     hoist-non-react-statics "^3.3.1"
     lodash "^4.0.0"
+    months "^2.1.0"
     prop-types "^15.5.10"
     xdate "^0.8.0"
 

--- a/packages/exoflex/package.json
+++ b/packages/exoflex/package.json
@@ -31,7 +31,7 @@
     "color": "^3.1.2",
     "lodash.mergewith": "^4.6.2",
     "react-native-animation-hooks": "^1.0.1",
-    "react-native-calendars": "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.1.tar.gz",
+    "react-native-calendars": "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.2.tar.gz",
     "react-native-collapsible": "^1.5.1",
     "react-native-modal-datetime-picker": "8.1.1",
     "react-native-multi-slider": "npm:@ptomasroos/react-native-multi-slider",

--- a/packages/exoflex/package.json
+++ b/packages/exoflex/package.json
@@ -5,9 +5,7 @@
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "types": "lib/typescript/src/index.d.ts",
-  "files": [
-    "lib/"
-  ],
+  "files": ["lib/"],
   "author": "KodeFox",
   "license": "MIT",
   "scripts": {
@@ -31,7 +29,7 @@
     "color": "^3.1.2",
     "lodash.mergewith": "^4.6.2",
     "react-native-animation-hooks": "^1.0.1",
-    "react-native-calendars": "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.2.tar.gz",
+    "react-native-calendars": "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.3.tar.gz",
     "react-native-collapsible": "^1.5.1",
     "react-native-modal-datetime-picker": "8.1.1",
     "react-native-multi-slider": "npm:@ptomasroos/react-native-multi-slider",
@@ -75,14 +73,8 @@
   "@react-native-community/bob": {
     "source": "src",
     "output": "lib",
-    "targets": [
-      "commonjs",
-      "module",
-      "typescript"
-    ],
-    "files": [
-      "src/"
-    ]
+    "targets": ["commonjs", "module", "typescript"],
+    "files": ["src/"]
   },
   "eslintConfig": {
     "extends": "kodefox/react-native"

--- a/packages/exoflex/package.json
+++ b/packages/exoflex/package.json
@@ -5,7 +5,9 @@
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "types": "lib/typescript/src/index.d.ts",
-  "files": ["lib/"],
+  "files": [
+    "lib/"
+  ],
   "author": "KodeFox",
   "license": "MIT",
   "scripts": {
@@ -29,7 +31,7 @@
     "color": "^3.1.2",
     "lodash.mergewith": "^4.6.2",
     "react-native-animation-hooks": "^1.0.1",
-    "react-native-calendars": "^1.212.0",
+    "react-native-calendars": "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.1.tar.gz",
     "react-native-collapsible": "^1.5.1",
     "react-native-modal-datetime-picker": "8.1.1",
     "react-native-multi-slider": "npm:@ptomasroos/react-native-multi-slider",
@@ -73,8 +75,14 @@
   "@react-native-community/bob": {
     "source": "src",
     "output": "lib",
-    "targets": ["commonjs", "module", "typescript"],
-    "files": ["src/"]
+    "targets": [
+      "commonjs",
+      "module",
+      "typescript"
+    ],
+    "files": [
+      "src/"
+    ]
   },
   "eslintConfig": {
     "extends": "kodefox/react-native"

--- a/packages/exoflex/yarn.lock
+++ b/packages/exoflex/yarn.lock
@@ -4401,6 +4401,13 @@ hoist-non-react-statics@^3.3.0:
   dependencies:
     react-is "^16.7.0"
 
+hoist-non-react-statics@^3.3.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 hosted-git-info@^2.1.4:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.4.tgz#44119abaf4bc64692a16ace34700fed9c03e2546"
@@ -6368,6 +6375,11 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+months@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/months/-/months-2.1.0.tgz#9385ae1968b84313dff223b11080058d1ec326fd"
+  integrity sha512-2M9gdDB/uVt304/hJ3k2UIquJhOV5dRjp9BovHmZSINaRp7pdJuHXxOcuSjmJaKNomFyYyu0y3LBigdWiAUEmQ==
+
 morgan@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
@@ -7323,12 +7335,13 @@ react-native-animation-hooks@^1.0.1:
   resolved "https://registry.yarnpkg.com/react-native-animation-hooks/-/react-native-animation-hooks-1.0.1.tgz#fcda58867d708084cc63c6fcd001f5375a40f45b"
   integrity sha512-s1o71m9sPpEYwFpHTdBouO50jzvyxIVB4MmNwfVGgPWkdL02zKOzyXcNuPJmoCuLIstUj5TBEwtnGk1WMFJx5A==
 
-react-native-calendars@^1.212.0:
-  version "1.212.0"
-  resolved "https://registry.yarnpkg.com/react-native-calendars/-/react-native-calendars-1.212.0.tgz#6070ae37c7a446da5a6fb1c24b71feda5021aafd"
-  integrity sha512-FrWabRJlUeTjCF8qx8cYAId4SbCMmVmO5eE791ykQaTG2/jvQJz2O3MF5QRjJHyaS/QdeEilKf9w/Mk43bM42Q==
+"react-native-calendars@https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.1.tar.gz":
+  version "1.22.0"
+  resolved "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.1.tar.gz#3750211597de33b4980d837724751f8aa56209ad"
   dependencies:
+    hoist-non-react-statics "^3.3.1"
     lodash "^4.0.0"
+    months "^2.1.0"
     prop-types "^15.5.10"
     xdate "^0.8.0"
 

--- a/packages/exoflex/yarn.lock
+++ b/packages/exoflex/yarn.lock
@@ -7335,9 +7335,9 @@ react-native-animation-hooks@^1.0.1:
   resolved "https://registry.yarnpkg.com/react-native-animation-hooks/-/react-native-animation-hooks-1.0.1.tgz#fcda58867d708084cc63c6fcd001f5375a40f45b"
   integrity sha512-s1o71m9sPpEYwFpHTdBouO50jzvyxIVB4MmNwfVGgPWkdL02zKOzyXcNuPJmoCuLIstUj5TBEwtnGk1WMFJx5A==
 
-"react-native-calendars@https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.2.tar.gz":
-  version "0.0.2"
-  resolved "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.2.tar.gz#1eb8276a06844c2fc66ade9ad94c74b081ab5816"
+"react-native-calendars@https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.3.tar.gz":
+  version "0.0.3"
+  resolved "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.3.tar.gz#60bd33bbd3cefa3ff0031e979b98ba766a3ab695"
   dependencies:
     hoist-non-react-statics "^3.3.1"
     lodash "^4.0.0"

--- a/packages/exoflex/yarn.lock
+++ b/packages/exoflex/yarn.lock
@@ -7335,9 +7335,9 @@ react-native-animation-hooks@^1.0.1:
   resolved "https://registry.yarnpkg.com/react-native-animation-hooks/-/react-native-animation-hooks-1.0.1.tgz#fcda58867d708084cc63c6fcd001f5375a40f45b"
   integrity sha512-s1o71m9sPpEYwFpHTdBouO50jzvyxIVB4MmNwfVGgPWkdL02zKOzyXcNuPJmoCuLIstUj5TBEwtnGk1WMFJx5A==
 
-"react-native-calendars@https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.1.tar.gz":
-  version "1.22.0"
-  resolved "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.1.tar.gz#3750211597de33b4980d837724751f8aa56209ad"
+"react-native-calendars@https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.2.tar.gz":
+  version "0.0.2"
+  resolved "https://github.com/oshimayoan/react-native-calendars/archive/oshimayoan-0.0.2.tar.gz#1eb8276a06844c2fc66ade9ad94c74b081ab5816"
   dependencies:
     hoist-non-react-statics "^3.3.1"
     lodash "^4.0.0"


### PR DESCRIPTION
Change the source of `react-native-calendars` to the fork one that has the implementation of an ability to change the month or the year directly when pressing on the header.

Those implementation is pretty similar to our original design for exoflex.

![Kapture 2020-04-17 at 10 32 17](https://user-images.githubusercontent.com/4923122/79529397-c06c6380-8096-11ea-9a6a-f074c749839d.gif)

## UPDATE
![Kapture 2020-04-28 at 15 28 43](https://user-images.githubusercontent.com/4923122/80465257-242f4000-8965-11ea-9f4f-5869bad6ff80.gif)

