### PR TITLE
feat(exoflex): add default a11y role for chip

### DIFF
--- a/packages/exoflex/src/components/Chip.tsx
+++ b/packages/exoflex/src/components/Chip.tsx
@@ -31,6 +31,7 @@ function Chip({
   textStyle,
   icon,
   iconStyle,
+  accessibilityRole,
   ...otherProps
 }: ChipProps) {
   let { colors, style: themeStyle } = useTheme();
@@ -39,6 +40,7 @@ function Chip({
 
   return (
     <TouchableOpacity
+      accessibilityRole={accessibilityRole || 'button'}
       activeOpacity={0.7}
       disabled={!onPress}
       onPress={onPress}


### PR DESCRIPTION
Add default `accessibilityRole` for web and native Chip component.
