### PR TITLE
chore: exclude test files from npm package

### DIFF
--- a/packages/exoflex/package.json
+++ b/packages/exoflex/package.json
@@ -5,7 +5,11 @@
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "types": "lib/typescript/src/index.d.ts",
-  "files": ["lib/"],
+  "files": [
+    "/lib",
+    "!/lib/typescript/test",
+    "!**/__tests__"
+  ],
   "author": "KodeFox",
   "license": "MIT",
   "scripts": {
@@ -73,8 +77,11 @@
   "@react-native-community/bob": {
     "source": "src",
     "output": "lib",
-    "targets": ["commonjs", "module", "typescript"],
-    "files": ["src/"]
+    "targets": [
+      "commonjs",
+      "module",
+      "typescript"
+    ]
   },
   "eslintConfig": {
     "extends": "kodefox/react-native"

--- a/packages/feetch/package.json
+++ b/packages/feetch/package.json
@@ -5,7 +5,11 @@
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "types": "lib/typescript/index.d.ts",
-  "files": ["lib/", "src/"],
+  "files": [
+    "lib/",
+    "src/",
+    "!**/__tests__"
+  ],
   "author": "KodeFox",
   "license": "MIT",
   "scripts": {
@@ -55,6 +59,10 @@
   "@react-native-community/bob": {
     "source": "src",
     "output": "lib",
-    "targets": ["commonjs", "module", "typescript"]
+    "targets": [
+      "commonjs",
+      "module",
+      "typescript"
+    ]
   }
 }

--- a/packages/flexship/package.json
+++ b/packages/flexship/package.json
@@ -8,7 +8,8 @@
   },
   "main": "dist/main.js",
   "files": [
-    "/dist"
+    "/dist",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "yarn test && yarn build-ts && chmod +x dist/main.js",

--- a/packages/miflex/package.json
+++ b/packages/miflex/package.json
@@ -5,7 +5,10 @@
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.ts",
   "types": "lib/typescript/index.d.ts",
-  "files": ["lib/"],
+  "files": [
+    "/lib",
+    "!**/__tests__"
+  ],
   "scripts": {
     "build": "yarn bob build",
     "format": "prettier --write \"src/**/*.ts\"",
@@ -30,8 +33,11 @@
   "@react-native-community/bob": {
     "source": "src",
     "output": "lib",
-    "targets": ["commonjs", "module", "typescript"],
-    "files": ["src/"]
+    "targets": [
+      "commonjs",
+      "module",
+      "typescript"
+    ]
   },
   "eslintConfig": {
     "extends": "kodefox"


### PR DESCRIPTION
Previously we would include our tests file in the npm packages.

For example, this is exoflex before this diff:
<img width="641" alt="image" src="https://user-images.githubusercontent.com/19742419/88256798-6529bd00-cce6-11ea-8202-347e0d72a8a7.png">

After:
<img width="680" alt="image" src="https://user-images.githubusercontent.com/19742419/88256872-94402e80-cce6-11ea-8c8f-21ae406d329c.png">

Not much changes in package sizes though, since the majority of the size came from our fonts.
