### PR TITLE
chore(exoflex): Match `package.json` version to npm package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   testing:
     docker:
-      - image: circleci/node:12.22.7
+      - image: circleci/node:16.10.0
 
     working_directory: ~/repo
 

--- a/packages/exoflex/package.json
+++ b/packages/exoflex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exoflex",
-  "version": "2.0.2",
+  "version": "3.4.4",
   "description": "",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",


### PR DESCRIPTION
Changes:

- Adjust `exoflex` `package.json` version to match the current nom version (Previously: `2.0.2` , Current: `3.4.4`).
- Update circleci/node docker tag to v16.10.0